### PR TITLE
Permitir enviar variaveis ao realizar uma chamada via Verto

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -18,11 +18,14 @@ const Actions = {
   logout: null,
 };
 
-Actions.call = (origin, destination) => {
+Actions.call = (origin, destination, variables) => {
   if (isNullOrUndefinedOrEmpty(destination)) {
     console.warn('Digite o numero do destinatário');
     return;
   }
+
+  let userVariables = {}
+  if (variables && typeof(variables) === 'object') Object.assign(userVariables, variables)
 
   Store.currentCall = HandleVerto.newCall({
     destination_number: destination,
@@ -37,6 +40,7 @@ Actions.call = (origin, destination) => {
     screenShare: false,
     dedEnc: false,
     mirrorInput: false,
+    userVariables
   });
 };
 


### PR DESCRIPTION
Alteração para permitir o usuário enviar variaveis customizadas para o Freeswitch, assim podemos pegar essas variaveis depois nos eventos do Freeswitch.

Na Api4Com vamos utilizar essa feature para geração de webhooks de chamadas originadas a partir do verto.